### PR TITLE
"oe_theme not found" during installation

### DIFF
--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -8,7 +8,6 @@ drupal:
     user: "root"
     password: ""
   post_install:
-    - "./vendor/bin/drush en oe_theme_helper -y"
     - "./vendor/bin/drush en config_devel -y"
     - "./vendor/bin/drush en oe_multilingual -y"
     - "./vendor/bin/drush en oe_multilingual_demo -y"


### PR DESCRIPTION
### Description
After running `./vendor/bin/run drupal:site-install`, an error is thrown that Drupal is not able to find the `oe_theme`.
This happens because the `oe_theme` is not yet enabled, but the `oe_theme_helper` is installed. The ECL template loader will try to fetch the `oe_theme` and this breaks the installation.

### Change log

- Removed: removed line that installs the oe_theme_helper as it's enabled later as dependency of the oe_theme.
