### PR TITLE
OPENEUROPA-615 : Make sure that splash page uses the original language

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/drupal-extension": "^4.0.0@alpha",
         "openeuropa/code-review": "^0.2",
         "openeuropa/task-runner": "^0.5",
-        "openeuropa/oe_theme": "^0.2",
+        "openeuropa/oe_theme": "dev-OPENEUROPA-615",
         "webflo/drupal-core-require-dev": "8.6.x"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/drupal-extension": "^4.0.0@alpha",
         "openeuropa/code-review": "^0.2",
         "openeuropa/task-runner": "^0.5",
-        "openeuropa/oe_theme": "dev-OPENEUROPA-615",
+        "openeuropa/oe_theme": "^0.3",
         "webflo/drupal-core-require-dev": "8.6.x"
     },
     "scripts": {

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -47,3 +47,17 @@ function oe_multilingual_language_fallback_candidates_alter(array &$candidates, 
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_language_selection_page_content().
+ *
+ * Replaces the language links labels with the native language version.
+ */
+function oe_multilingual_preprocess_language_selection_page_content(&$variables): void {
+  $original_languages = \Drupal::service('oe_multilingual.helper')->getLanguageNameList();
+  foreach ($variables['language_links']['#items'] as $langcode => &$item) {
+    if (isset($original_languages[$langcode])) {
+      $item['#title'] = $original_languages[$langcode];
+    }
+  }
+}

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -61,3 +61,12 @@ function oe_multilingual_preprocess_language_selection_page_content(&$variables)
     }
   }
 }
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function oe_multilingual_theme_suggestions_page_alter(array &$suggestions, array $variables): void {
+  if ('language_selection_page' == \Drupal::request()->attributes->get('_route')) {
+    array_splice($suggestions, 1, 0, 'page__language_selection_splash');
+  }
+}

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -61,12 +61,3 @@ function oe_multilingual_preprocess_language_selection_page_content(&$variables)
     }
   }
 }
-
-/**
- * Implements hook_theme_suggestions_HOOK_alter().
- */
-function oe_multilingual_theme_suggestions_page_alter(array &$suggestions, array $variables): void {
-  if ('language_selection_page' == \Drupal::request()->attributes->get('_route')) {
-    array_splice($suggestions, 1, 0, 'page__language_selection_splash');
-  }
-}

--- a/tests/features/language-selection.feature
+++ b/tests/features/language-selection.feature
@@ -20,7 +20,7 @@ Feature: Language selection
     Given I am on the homepage
     Then I should be redirected to the language selection page
 
-    When I click "French"
+    When I click "Français"
     Then the url should match "/fr"
 
   Scenario: Users visiting a page should be presented with the language selection page,
@@ -29,5 +29,5 @@ Feature: Language selection
     Given I visit the "Test page" content
     Then I should be redirected to the language selection page
 
-    When I click "French"
+    When I click "Français"
     Then the url should match "/fr/page-de-test"


### PR DESCRIPTION
## OPENEUROPA-615

### Description

Make sure that language switcher in splash page uses their original language .

### Change log

- Changed:
composer.json
oe_multilingual.module
tests/features/language-selection.feature


### Commands

drush cr
