### PR TITLE
OPENEUROPA-637: Removed unnecesary modules from build.

### DIFF
--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -11,12 +11,9 @@ drupal:
     profile: "minimal"
     name: "OpenEuropa"
   post_install:
-    - "./vendor/bin/drush en config_devel -y"
-    - "./vendor/bin/drush en devel -y"
     - "./vendor/bin/drush en oe_multilingual -y"
     - "./vendor/bin/drush en oe_multilingual_demo -y"
     - "./vendor/bin/drush en oe_theme_helper -y"
-    - "./vendor/bin/drush en toolbar -y"
     - "./vendor/bin/drush theme:enable oe_theme -y"
     - "./vendor/bin/drush theme:enable seven -y"
     - "./vendor/bin/drush config-set system.theme default oe_theme -y"


### PR DESCRIPTION
## OPENEUROPA-637
### Description

Currently in OE Multilingual the Behat tests are executed in a "dirty" installation which is intended as a development build. In addition to Drupal core it enables a bunch of development tools, like config_devel, devel, oe_multilingual_demo, oe_theme, ...

In order to be sure that this module works properly as a standalone component we need to run the tests against the testing profile (if this is possible) without enabling any other modules.

### Change log

- Removed: Removed unnecesary modules during build



