### PR TITLE
OPENEUROPA-634: Drupal latest stable version, 8.6@alpha.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.1",
         "drupal/administration_language_negotiation": "~1.5",
-        "drupal/core": "~8.6",
+        "drupal/core": "~8.6@alpha",
         "drupal/language_selection_page": "^2.2",
         "drupal/pathauto": "^1.2"
     },
@@ -23,7 +23,7 @@
         "drush/drush": "^9",
         "openeuropa/code-review": "~0.2",
         "openeuropa/task-runner": "^0.5",
-        "webflo/drupal-core-require-dev": "~8.6"
+        "webflo/drupal-core-require-dev": "~8.6@alpha"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",


### PR DESCRIPTION
## OPENEUROPA-634

### Description

Use the latest "stable" version of Drupal in all components, for now, it is an alpha version, however, we decide to go for it as it will be released on September and until that no site will be using OPENEUROPA on prod, so it is a safe choice.

### Change log

Added: version 8.6@alpha

