### PR TITLE
OPENEUROPA-773: As a dev. I have to make sure Portuguese language code is "pt-pt"

### DIFF
--- a/config/install/language.entity.pt-pt.yml
+++ b/config/install/language.entity.pt-pt.yml
@@ -1,7 +1,7 @@
 langcode: en
 status: true
 dependencies: {  }
-id: pt
+id: pt-pt
 label: Portuguese
 direction: ltr
 weight: 12

--- a/oe_multilingual.install
+++ b/oe_multilingual.install
@@ -41,6 +41,12 @@ function oe_multilingual_install() {
     ->set('url.prefixes.en', 'en')
     ->save();
 
+  // Make sure that Portuguese language prefix is set to "pt".
+  \Drupal::configFactory()
+    ->getEditable('language.negotiation')
+    ->set('url.prefixes.pt-pt', 'pt')
+    ->save();
+
   /** @var \Drupal\oe_multilingual\LanguageNegotiationSetterInterface $setter */
   $setter = \Drupal::service('oe_multilingual.language_negotiation_setter');
 

--- a/src/MultilingualHelper.php
+++ b/src/MultilingualHelper.php
@@ -110,7 +110,7 @@ class MultilingualHelper implements MultilingualHelperInterface {
       'mt' => ['Maltese', 'Malti'],
       'nl' => ['Dutch', 'Nederlands'],
       'pl' => ['Polish', 'polski'],
-      'pt' => ['Portuguese', 'português'],
+      'pt-pt' => ['Portuguese', 'português'],
       'ro' => ['Romanian', 'română'],
       'sk' => ['Slovak', 'slovenčina'],
       'sl' => ['Slovenian', 'slovenščina'],

--- a/tests/features/language-selection.feature
+++ b/tests/features/language-selection.feature
@@ -27,7 +27,7 @@ Feature: Language selection
     Then the url should match "/fr"
 
     When I click "português"
-    Then the url should match "/pt-pt"
+    Then the url should match "/pt"
 
   Scenario: Users visiting a page should be presented with the language selection page,
             if no language is detected in the URL.
@@ -39,4 +39,4 @@ Feature: Language selection
     Then the url should match "/fr/page-de-test"
 
     When I click "português"
-    Then the url should match "/pt-pt/pagina-de-teste"
+    Then the url should match "/pt/pagina-de-teste"

--- a/tests/features/language-selection.feature
+++ b/tests/features/language-selection.feature
@@ -14,6 +14,9 @@ Feature: Language selection
     And the following "Spanish" translation for the "Demo translatable page" with title "Test page":
       | Title | Página de prueba |
       | Body  | Hola Mundo       |
+    And the following "Portuguese" translation for the "Demo translatable page" with title "Test page":
+      | Title | Página de teste |
+      | Body  | Olá Mundo       |
 
   Scenario: When I visit the homepage I'm presented with a language selection page
 
@@ -23,6 +26,9 @@ Feature: Language selection
     When I click "français"
     Then the url should match "/fr"
 
+    When I click "português"
+    Then the url should match "/pt-pt"
+
   Scenario: Users visiting a page should be presented with the language selection page,
             if no language is detected in the URL.
 
@@ -31,3 +37,6 @@ Feature: Language selection
 
     When I click "français"
     Then the url should match "/fr/page-de-test"
+
+    When I click "português"
+    Then the url should match "/pt-pt/pagina-de-teste"


### PR DESCRIPTION
## OPENEUROPA-773

### Description

Changed the Portuguese language code back to pt-pt. 

Note that the URL langcode is pt-pt and this was specifically mentioned as outside the scope of the ticket even though the end goal will be to have the URL code "pt"

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

