### PR TITLE
OPENEUROPA-660: Make it impossible for a content editor to create an initial version of a content in any language other than the default language

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -6,6 +6,7 @@ default:
       contexts:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\Tests\oe_multilingual\Behat\DrupalContext
         - Drupal\Tests\oe_multilingual\Behat\MinkContext
   extensions:
@@ -18,6 +19,8 @@ default:
       api_driver: "drupal"
       drupal:
         drupal_root: "build"
+      selectors: &drupal-selectors
+        success_message_selector: ".messages--status"
       region_map:
         "language switcher": "#block-oe-multilingual-language-switcher"
         "language dialog": "#block-oe-multilingual-language-switcher"

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,9 @@
         "drush/drush": "~9.0@stable",
         "openeuropa/code-review": "^1.0.0-alpha4",
         "openeuropa/drupal-core-require-dev": "^8.6",
-        "openeuropa/task-runner": "~1.0",
-        "phpunit/phpunit": "~6.0"
+        "openeuropa/task-runner": "~1.0.0-beta2",
+        "phpunit/phpunit": "~6.0",
+        "symfony/browser-kit": "~3.0||~4.0"
     },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/oe_multilingual.services.yml
+++ b/oe_multilingual.services.yml
@@ -5,3 +5,7 @@ services:
   oe_multilingual.helper:
     class: Drupal\oe_multilingual\MultilingualHelper
     arguments: ['@entity.repository', '@current_route_match', '@language_manager']
+  oe_multilingual.content_language_settings:
+    class: Drupal\oe_multilingual\MultilingualConfigOverride
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/src/MultilingualConfigOverride.php
+++ b/src/MultilingualConfigOverride.php
@@ -7,7 +7,7 @@ use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
 
 /**
- * Override some config values for customizing default behavior.
+ * Override configuration values related to multilingual elements.
  */
 class MultilingualConfigOverride implements ConfigFactoryOverrideInterface {
 
@@ -17,6 +17,8 @@ class MultilingualConfigOverride implements ConfigFactoryOverrideInterface {
   public function loadOverrides($names) {
     $overrides = [];
     foreach ($names as $config_name) {
+      // Force the default site's language as the default language and prevent
+      // the users from changing it when creating a node.
       if (preg_match('/^language\.content_settings\.node\.(.*)$/', $config_name)) {
         $overrides[$config_name] = [
           'default_langcode' => 'site_default',

--- a/src/MultilingualConfigOverride.php
+++ b/src/MultilingualConfigOverride.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\oe_multilingual;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Config\StorableConfigBase;
 
 /**
  * Override configuration values related to multilingual elements.
@@ -14,7 +17,7 @@ class MultilingualConfigOverride implements ConfigFactoryOverrideInterface {
   /**
    * {@inheritdoc}
    */
-  public function loadOverrides($names) {
+  public function loadOverrides($names): array {
     $overrides = [];
     foreach ($names as $config_name) {
       // Force the default site's language as the default language and prevent
@@ -33,21 +36,21 @@ class MultilingualConfigOverride implements ConfigFactoryOverrideInterface {
   /**
    * {@inheritdoc}
    */
-  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION): ?StorableConfigBase {
     return NULL;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getCacheSuffix() {
+  public function getCacheSuffix(): string {
     return 'oe_multilingual.language_configs_override';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getCacheableMetadata($name) {
+  public function getCacheableMetadata($name): CacheableMetadata {
     return new CacheableMetadata();
   }
 

--- a/src/MultilingualConfigOverride.php
+++ b/src/MultilingualConfigOverride.php
@@ -19,7 +19,7 @@ class MultilingualConfigOverride implements ConfigFactoryOverrideInterface {
     foreach ($names as $config_name) {
       // Force the default site's language as the default language and prevent
       // the users from changing it when creating a node.
-      if (preg_match('/^language\.content_settings\.node\.(.*)$/', $config_name)) {
+      if (strpos($config_name, 'language.content_settings.node.') !== FALSE) {
         $overrides[$config_name] = [
           'default_langcode' => 'site_default',
           'language_alterable' => FALSE,

--- a/src/MultilingualConfigOverride.php
+++ b/src/MultilingualConfigOverride.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\oe_multilingual;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Override some config values for customizing default behavior.
+ */
+class MultilingualConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    foreach ($names as $config_name) {
+      if (preg_match('/^language\.content_settings\.node\.(.*)$/', $config_name)) {
+        $overrides[$config_name] = [
+          'default_langcode' => 'site_default',
+          'language_alterable' => FALSE,
+        ];
+      }
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'oe_multilingual.language_configs_override';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+}

--- a/tests/Behat/DrupalContext.php
+++ b/tests/Behat/DrupalContext.php
@@ -207,7 +207,7 @@ class DrupalContext extends RawDrupalContext {
    * @param string $content_type_name
    *   Content type name.
    *
-   * @Given I am visiting the :content_type_name creation page
+   * @Given I visit the :content_type_name creation page
    */
   public function iAmVisitingTheCreationPage(string $content_type_name): void {
     $node_bundle = $this->getEntityTypeByLabel($content_type_name);
@@ -246,8 +246,8 @@ class DrupalContext extends RawDrupalContext {
     }
 
     $node_translation_languages = $node->getTranslationLanguages();
-    if (!is_array($node_translation_languages) || count($node_translation_languages) !== 1) {
-      throw new \RuntimeException("We don't have the correct number of translations.");
+    if (count($node_translation_languages) !== 1) {
+      throw new \RuntimeException("The node should have only one translation.");
     }
 
     $node_language = key($node_translation_languages);

--- a/tests/Behat/DrupalContext.php
+++ b/tests/Behat/DrupalContext.php
@@ -232,7 +232,7 @@ class DrupalContext extends RawDrupalContext {
   }
 
   /**
-   * Check that we have correct language for initial translation.
+   * Check that we have the correct language for initial translation.
    *
    * @param string $title
    *   Title of node.
@@ -242,17 +242,17 @@ class DrupalContext extends RawDrupalContext {
   public function assertOnlyDefaultLanguageTranslationExist(string $title): void {
     $node = $this->getEntityByLabel('node', $title);
     if (!$node) {
-      throw new \RuntimeException("Node '{$title}' is not exist.");
+      throw new \RuntimeException("Node '{$title}' doesn't exist.");
     }
 
     $node_translation_languages = $node->getTranslationLanguages();
     if (!is_array($node_translation_languages) || count($node_translation_languages) !== 1) {
-      throw new \RuntimeException("We have not correct number of translations.");
+      throw new \RuntimeException("We don't have the correct number of translations.");
     }
 
     $node_language = key($node_translation_languages);
     if ($node_language != \Drupal::languageManager()->getDefaultLanguage()->getId()) {
-      throw new \RuntimeException("Original translation language of the '{$title}' node is not equal to site's default language.");
+      throw new \RuntimeException("Original translation language of the '{$title}' node is not the site's default language.");
     }
   }
 

--- a/tests/features/content-default-language.feature
+++ b/tests/features/content-default-language.feature
@@ -1,13 +1,13 @@
 @api
 Feature: Content initial language.
-  In order to be create content
+  In order to create content
   As a editor
-  I want to make sure that it impossible for a content editor to create an initial version of a content in any language other
-  than the site default language
+  I want to make sure that it is not possible for a content editor to create a node's initial version in any language
+  other than the site's default language
 
-  Scenario: Content editor try to create node without possibility select initial node language
+  Scenario: As an editor, when I create a node I can not select the initial node language
     Given I am logged in as a user with the "create oe_demo_translatable_page content" permission
-    And I am visiting the "Demo translatable page" creation page
+    And I visit the "Demo translatable page" creation page
     Then I should not see the field "Language"
 
     When I fill in "Title" with "Title Default value"

--- a/tests/features/content-default-language.feature
+++ b/tests/features/content-default-language.feature
@@ -1,0 +1,19 @@
+@api
+Feature: Conant creation default language
+  In order to be create content
+  As a editor
+  I want to make sure that it impossible for a content editor to create an initial version of a content in any language other
+  than the site default language
+
+  Scenario: When I am logged in as an editor
+    Given I am logged in as a user with the "create oe_demo_translatable_page content,translate oe_demo_translatable_page node" permission
+    And I am visiting the "Demo translatable page" create node page
+    Then I should not see selectbox with label "Language"
+
+    When I fill in "Title" with "Title Default value"
+    And I fill in "Body" with "Body Default value"
+    And I press "Save"
+    Then I should see the success message "Demo translatable page Title Default value has been created."
+
+    When I click "Translate"
+    Then I have to be sure that "Title Default value" node translation only in site default language.

--- a/tests/features/content-default-language.feature
+++ b/tests/features/content-default-language.feature
@@ -6,14 +6,12 @@ Feature: Content initial language.
   than the site default language
 
   Scenario: Content editor try to create node without possibility select initial node language
-    Given I am logged in as a user with the "create oe_demo_translatable_page content,translate oe_demo_translatable_page node" permission
-    And I am visiting the "Demo translatable page" create node page
-    Then I should not see selectbox with label "Language"
+    Given I am logged in as a user with the "create oe_demo_translatable_page content" permission
+    And I am visiting the "Demo translatable page" creation page
+    Then I should not see the field "Language"
 
     When I fill in "Title" with "Title Default value"
     And I fill in "Body" with "Body Default value"
     And I press "Save"
     Then I should see the success message "Demo translatable page Title Default value has been created."
-
-    When I click "Translate"
-    Then I have to be sure that "Title Default value" node translation only in site default language.
+    And The only available translation for "Title Default value" is in the site's default language

--- a/tests/features/content-default-language.feature
+++ b/tests/features/content-default-language.feature
@@ -1,11 +1,11 @@
 @api
-Feature: Conant creation default language
+Feature: Content initial language.
   In order to be create content
   As a editor
   I want to make sure that it impossible for a content editor to create an initial version of a content in any language other
   than the site default language
 
-  Scenario: When I am logged in as an editor
+  Scenario: Content editor try to create node without possibility select initial node language
     Given I am logged in as a user with the "create oe_demo_translatable_page content,translate oe_demo_translatable_page node" permission
     And I am visiting the "Demo translatable page" create node page
     Then I should not see selectbox with label "Language"


### PR DESCRIPTION
## OPENEUROPA-660

### Description


Our content translation strategy requires every piece of content to be first created in the site's default language (which will in most cases be English, but there might be exceptions). Once the English version has been created any desired translations can then be added.

We should make it impossible for a content editor to create an initial version of a content in any language other than the default language.

module: "oe_multilingual"

### Change log

- Added:
- Changed: 
- Deprecated:
- Removed:
- Fixed:
- Security:

