### PR TITLE
OPENEUROPA-1326: Use patched core from drupal-core-require.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,13 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.6",
         "drupal/language_selection_page": "^2.2",
         "drupal/pathauto": "^1.2",
+        "openeuropa/drupal-core-require": "^8.6",
         "php": "^7.1"
     },
     "require-dev": {
         "composer/installers": "~1.5",
-        "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5.2",
         "drupal/config_devel": "~1.2",
         "drupal/devel": "~1.2",
@@ -48,11 +47,6 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
-        "patches": {
-            "drupal/core": {
-                "https://www.drupal.org/project/drupal/issues/2189267": "https://www.drupal.org/files/issues/2018-09-14/2189267-88.patch"
-            }
-        },
         "installer-paths": {
             "build/core": ["type:drupal-core"],
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],


### PR DESCRIPTION
## OPENEUROPA-1326

### Description

Use patched core from drupal-core-require.

### Change log

- Added: Composer dependency from "openeuropa/drupal-core-require".
- Removed: Composer dependency from "drupal/core".
- Removed: Composer dependency from "cweagans/composer-patches".
- Removed: Patch for DO issue #2189267.

