### PR TITLE
OPENEUROPA-1386: Fixing language selection page cache bug.

### DIFF
--- a/modules/oe_multilingual_selection_page/oe_multilingual_selection_page.module
+++ b/modules/oe_multilingual_selection_page/oe_multilingual_selection_page.module
@@ -15,13 +15,20 @@ function oe_multilingual_selection_page_preprocess_language_selection_page_conte
   // Generate an array suitable for use in the ecl-language-list component.
   foreach ($variables['language_links']['#items'] as $key => $value) {
     $language_code = $key;
-    $url = $value['#url']->toString();
+    /** @var \Drupal\Core\Url $url */
+    $url = $value['#url'];
 
     $variables['languages'][] = [
       'href' => $url,
       'hreflang' => $language_code,
       'label' => $value['#title'],
       'lang' => $language_code,
+    ];
+
+    // We need to set vary by URL because the links need to redirect to the
+    // initial requested language.
+    $variables['#cache'] = [
+      'contexts' => ['url'],
     ];
   }
 }


### PR DESCRIPTION
## OPENEUROPA-1386

### Description

When altering the links on the language selection page to pass them to the ECL template, we miss adding caches by context. This is needed because the page needs to build those links depending on the requested page. 

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

