### PR TITLE
OPENEUROPA-1382: Assert that the language switcher has appropriate li…

### DIFF
--- a/config/install/language.entity.lt.yml
+++ b/config/install/language.entity.lt.yml
@@ -4,5 +4,5 @@ dependencies: {  }
 id: lt
 label: Lithuanian
 direction: ltr
-weight: 12
+weight: 13
 locked: false

--- a/config/install/language.entity.lv.yml
+++ b/config/install/language.entity.lv.yml
@@ -4,5 +4,5 @@ dependencies: {  }
 id: lv
 label: Latvian
 direction: ltr
-weight: 13
+weight: 12
 locked: false

--- a/tests/Behat/MinkContext.php
+++ b/tests/Behat/MinkContext.php
@@ -29,18 +29,13 @@ class MinkContext extends RawMinkContext {
    * @Then I should see the following links in the language switcher:
    */
   public function assertLinksInRegion(TableNode $links): void {
-    $switcher = $this->getSession()->getPage()->find('css', '#block-oe-multilingual-language-switcher');
-    $switcher_links = $switcher->findAll('css', 'a');
+    $switcher_links = $this->getSession()->getPage()->findAll('css', '#block-oe-multilingual-language-switcher a');
     $actual_links = [];
     /** @var \Behat\Mink\Element\NodeElement $switcher_link */
     foreach ($switcher_links as $switcher_link) {
       $actual_links[] = $switcher_link->getText();
     }
-    $expected_links = [];
-    foreach ($links->getRows() as $row) {
-      $expected_links[] = $row[0];
-
-    }
+    $expected_links = array_keys($links->getRowsHash());
     Assert::assertEquals($expected_links, $actual_links);
   }
 

--- a/tests/Behat/MinkContext.php
+++ b/tests/Behat/MinkContext.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\oe_multilingual\Behat;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
+use PHPUnit\Framework\Assert;
 
 /**
  * Class MinkContext.
@@ -29,13 +30,18 @@ class MinkContext extends RawMinkContext {
    */
   public function assertLinksInRegion(TableNode $links): void {
     $switcher = $this->getSession()->getPage()->find('css', '#block-oe-multilingual-language-switcher');
-
-    foreach ($links->getRows() as $row) {
-      $result = $switcher->findLink($row[0]);
-      if (empty($result)) {
-        throw new \Exception(sprintf('No link to "%s" in the "%s" region on the page %s', $row[0], $region, $this->getSession()->getCurrentUrl()));
-      }
+    $switcher_links = $switcher->findAll('css', 'a');
+    $actual_links = [];
+    /** @var \Behat\Mink\Element\NodeElement $switcher_link */
+    foreach ($switcher_links as $switcher_link) {
+      $actual_links[] = $switcher_link->getText();
     }
+    $expected_links = [];
+    foreach ($links->getRows() as $row) {
+      $expected_links[] = $row[0];
+
+    }
+    Assert::assertEquals($expected_links, $actual_links);
   }
 
 }

--- a/tests/features/language-switcher.feature
+++ b/tests/features/language-switcher.feature
@@ -18,8 +18,8 @@ Feature: Language selection
       | Gaeilge     |
       | hrvatski    |
       | italiano    |
-      | latviešu    |
       | lietuvių    |
+      | latviešu    |
       | magyar      |
       | Malti       |
       | Nederlands  |

--- a/tests/features/language-switcher.feature
+++ b/tests/features/language-switcher.feature
@@ -18,8 +18,8 @@ Feature: Language selection
       | Gaeilge     |
       | hrvatski    |
       | italiano    |
-      | lietuvių    |
       | latviešu    |
+      | lietuvių    |
       | magyar      |
       | Malti       |
       | Nederlands  |


### PR DESCRIPTION
…nks and in the correct order.

## OPENEUROPA-1384
### Description

The behat test that checks wether the language switcher contains the correct link translations must also check the ordering.

### Change log

- Added: Check for link ordering in language switcher


