### PR TITLE
OPENEUROPA-1350: Remove multilingual patch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,11 +53,6 @@
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],
             "build/modules/contrib/{$name}": ["type:drupal-module"],
             "build/themes/contrib/{$name}": ["type:drupal-theme"]
-        },
-        "patches": {
-            "drupal/core": {
-                "https://www.drupal.org/project/drupal/issues/2189267": "https://www.drupal.org/files/issues/2018-09-14/2189267-88.patch"
-            }
         }
     },
     "config": {


### PR DESCRIPTION
## OPENEUROPA-1350

### Description

We added the following patch in OE Multilingual to ensure the content languages work:

https://www.drupal.org/project/drupal/issues/2189267

However, the patch was merged so we need to remove it as soon as a new Drupal release is made that includes it. It was merged in 8.6 and 8.7

### Change log

- Removed: Multilingual drupal patch


