### PR TITLE
OPENEUROPA-1609 Fix behat.yml.dist to use drupal-extension properly.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -17,7 +17,7 @@ default:
               French administration home: 'fr/admin'
               demo content creation: 'node/add/oe_demo_translatable_page'
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       selenium2: ~
       javascript_session: selenium2

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
         "drupal/devel": "~1.2",
-        "drupal/drupal-extension": "^4.0.0@beta",
+        "drupal/drupal-extension": "^4.0",
         "drush/drush": "~9.0@stable",
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "^1.0.0-alpha4",


### PR DESCRIPTION
After moving from drupal-extension v3 to v4 Drupal\MinkExtension has to be used.