### PR TITLE
OPENEUROPA-1674: Make sure reenabling any language preserves configuration.

### DIFF
--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\Core\Url;
 
@@ -60,6 +62,22 @@ function oe_multilingual_preprocess_language_selection_page_content(&$variables)
   foreach ($variables['language_links']['#items'] as $langcode => &$item) {
     if (isset($original_languages[$langcode])) {
       $item['#title'] = $original_languages[$langcode]->getName();
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * Make sure whenever we add or re-add a language it follows the configuration
+ * set by the module's configuration files.
+ */
+function oe_multilingual_configurable_language_presave(EntityInterface $entity) {
+  $storage = new FileStorage(drupal_get_path('module', 'oe_multilingual') . '/config/install');
+  $values = $storage->read('language.entity.' . $entity->id());
+  if ($values) {
+    foreach ($values as $key => $value) {
+      $entity->set($key, $value);
     }
   }
 }

--- a/tests/Kernel/InstallationTest.php
+++ b/tests/Kernel/InstallationTest.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\oe_multilingual\Kernel;
 
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationSelected;
 use Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationUrl;
 use Drupal\oe_multilingual\Plugin\LanguageNegotiation\LanguageNegotiationAdmin;
@@ -54,30 +53,33 @@ class InstallationTest extends KernelTestBase {
   }
 
   /**
-   * Test languages keep the configuration after being deleted.
+   * Test languages keep the configuration after being deleted and recreated.
    */
   public function testLanguageConfiguration(): void {
     // Delete a language.
-    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $language_manager */
-    $entity_manager = $this->container->get('entity_type.manager');
-    $storage = $entity_manager->getStorage('configurable_language');
+    $storage = $this->container->get('entity_type.manager')->getStorage('configurable_language');
     /** @var \Drupal\language\Entity\ConfigurableLanguage $old_language */
     $old_language = $storage->load('fr');
     $old_language->delete();
 
-    // Assert language is deleted.
+    // Assert the language is deleted.
     $language = $storage->load('fr');
     $this->assertNull($language);
 
     // Create the same language.
-    /** @var \Drupal\language\Entity\ConfigurableLanguage $new_language */
-    $new_language = new ConfigurableLanguage(['id' => 'fr'], 'configurable_language');
+    /** @var \Drupal\language\ConfigurableLanguageInterface $new_language */
+    $new_language = $storage->create(['id' => 'fr']);
     $new_language->save();
     $new_language = $storage->load('fr');
 
+    // Assert the same values apply.
     $this->assertEquals($old_language->id(), $new_language->id());
     $this->assertEquals($old_language->getWeight(), $new_language->getWeight());
     $this->assertEquals($old_language->getName(), $new_language->getName());
+
+    // Ensure the correct translation is also present.
+    $translation = $this->container->get('language_manager')->getLanguageConfigOverride('fr', 'language.entity.fr');
+    $this->assertEquals('français', $translation->get('label'));
   }
 
   /**


### PR DESCRIPTION
## OPENEUROPA-1674

### Description

When re-enabling any of the supported languages, the original configuration needs to be restored


