### PR TITLE
OPENEUROPA-1754: Move content language switcher to header.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -32,6 +32,6 @@ default:
       region_map:
         "language switcher": "#block-oe-multilingual-language-switcher"
         "language dialog": "#block-oe-multilingual-language-switcher"
-        page header: ".region-content"
+        "page content": ".region-content"
   formatters:
     progress: ~

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -137,7 +137,7 @@ function oe_multilingual_page_header_pre_render(array $build): array {
   // Normalize the links to an array of options suitable for the ECL
   // "ecl-lang-select-pages" template.
   $content['#language_switcher']['options'] = [];
-  foreach ($language_provider->getEntityAvailableLanguages($entity) as $language_code => $link) {
+  foreach ($language_provider->getAvailableEntityLanguages($entity) as $language_code => $link) {
     /** @var \Drupal\Core\Url $url */
     $url = $link['url'];
     $href = $url

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -7,9 +7,7 @@
 
 declare(strict_types = 1);
 
-use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Config\FileStorage;
-use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\Core\Url;
@@ -82,78 +80,4 @@ function oe_multilingual_configurable_language_presave(EntityInterface $entity) 
       $entity->set($key, $value);
     }
   }
-}
-
-/**
- * Implements hook_block_view_BASE_BLOCK_ID_alter() for the Page Header block.
- */
-function oe_multilingual_block_view_oe_theme_helper_page_header_alter(array &$build, BlockPluginInterface $block) {
-  $build['#pre_render'][] = 'oe_multilingual_page_header_pre_render';
-}
-
-/**
- * Pre-render callback for the Page Header block alteration.
- *
- * We use this to add the language switcher
- * to the page header if OpenEuropa Theme is being used.
- *
- * @param array $build
- *   The built render array of the block.
- *
- * @see \Drupal\oe_theme_helper\Plugin\Block\PageHeaderBlock
- *
- * @return array
- *   The built render array of the block.
- */
-function oe_multilingual_page_header_pre_render(array $build): array {
-  // Get required services.
-  $multilingual_helper = \Drupal::service('oe_multilingual.helper');
-  $language_provider = \Drupal::service('oe_multilingual.language_provider');
-  $language_manager = \Drupal::languageManager();
-
-  $entity = $multilingual_helper->getEntityFromCurrentRoute();
-  // Bail out if there is no entity or if it's not a content entity.
-  if (!$entity || !$entity instanceof ContentEntityInterface) {
-    return $build;
-  }
-
-  // Render the links only if the current entity translation language is not
-  // the same as the current site language.
-  /** @var \Drupal\Core\Entity\EntityInterface $translation */
-  $translation = $multilingual_helper->getCurrentLanguageEntityTranslation($entity);
-  $current_language = $language_manager->getCurrentLanguage();
-  if ($translation->language()->getId() === $current_language->getId()) {
-    return $build;
-  }
-
-  $content = &$build['content'];
-
-  $content['#language_switcher']['current'] = $translation->language()->getName();
-
-  /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
-  $languages = $language_manager->getNativeLanguages();
-  $content['#language_switcher']['unavailable'] = $languages[$current_language->getId()]->getName();
-
-  // Normalize the links to an array of options suitable for the ECL
-  // "ecl-lang-select-pages" template.
-  $content['#language_switcher']['options'] = [];
-  foreach ($language_provider->getEntityAvailableLanguages($entity) as $language_code => $link) {
-    /** @var \Drupal\Core\Url $url */
-    $url = $link['url'];
-    $href = $url
-      ->setOptions(['language' => $link['language']])
-      ->setAbsolute(TRUE)
-      ->toString();
-
-    $content['#language_switcher']['options'][] = [
-      'href' => $href,
-      'hreflang' => $language_code,
-      'label' => $link['title'],
-      'lang' => $language_code,
-    ];
-  }
-
-  $content['#language_switcher']['is_primary'] = TRUE;
-
-  return $build;
 }

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -110,12 +111,18 @@ function oe_multilingual_page_header_pre_render(array $build): array {
   $multilingual_helper = \Drupal::service('oe_multilingual.helper');
   $content_language_switcher_provider = \Drupal::service('oe_multilingual.content_language_switcher_provider');
   $language_manager = \Drupal::languageManager();
+  $cache = new CacheableMetadata();
+  $cache->addCacheContexts(['languages:language_content']);
 
   $entity = $multilingual_helper->getEntityFromCurrentRoute();
   // Bail out if there is no entity or if it's not a content entity.
   if (!$entity || !$entity instanceof ContentEntityInterface) {
+    $cache->applyTo($build);
     return $build;
   }
+
+  $cache->addCacheableDependency($entity);
+  $cache->applyTo($build);
 
   // Render the links only if the current entity translation language is not
   // the same as the current site language.

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -7,7 +7,9 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\Core\Url;
@@ -80,4 +82,77 @@ function oe_multilingual_configurable_language_presave(EntityInterface $entity) 
       $entity->set($key, $value);
     }
   }
+}
+
+/**
+ * Implements hook_block_view_BASE_BLOCK_ID_alter() for the Page Header block.
+ */
+function oe_multilingual_block_view_oe_theme_helper_page_header_alter(array &$build, BlockPluginInterface $block) {
+  $build['#pre_render'][] = 'oe_multilingual_page_header_pre_render';
+}
+
+/**
+ * Pre-render callback for the Page Header block alteration.
+ *
+ * We use this to add the language switcher
+ * to the page header if OpenEuropa Theme is being used.
+ *
+ * @param array $build
+ *   The built render array of the block.
+ *
+ * @see \Drupal\oe_theme_helper\Plugin\Block\PageHeaderBlock
+ *
+ * @return array
+ *   The built render array of the block.
+ */
+function oe_multilingual_page_header_pre_render(array $build): array {
+  $content = &$build['content'];
+
+  // Get required services.
+  $multilingual_helper = \Drupal::service('oe_multilingual.helper');
+  $language_provider = \Drupal::service('oe_multilingual.language_provider');
+  $language_manager = \Drupal::languageManager();
+
+  $entity = $multilingual_helper->getEntityFromCurrentRoute();
+  // Bail out if there is no entity or if it's not a content entity.
+  if (!$entity || !$entity instanceof ContentEntityInterface) {
+    return $build;
+  }
+
+  // Render the links only if the current entity translation language is not
+  // the same as the current site language.
+  /** @var \Drupal\Core\Entity\EntityInterface $translation */
+  $translation = $multilingual_helper->getCurrentLanguageEntityTranslation($entity);
+  $current_language = $language_manager->getCurrentLanguage();
+  if ($translation->language()->getId() === $current_language->getId()) {
+    return $build;
+  }
+
+  $available_languages = $language_provider->getEntityAvailableLanguages($entity);
+  $content['#language_switcher']['current'] = $translation->language()->getName();
+  /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
+  $languages = $language_manager->getNativeLanguages();
+  $content['#language_switcher']['unavailable'] = $languages[$current_language->getId()]->getName();
+
+  // Normalize the links to an array of options suitable for the ECL
+  // "ecl-lang-select-pages" template.
+  $content['#language_switcher']['options'] = [];
+  foreach ($available_languages as $language_code => $link) {
+    /** @var \Drupal\Core\Url $url */
+    $url = $link['url'];
+    $href = $url
+      ->setOptions(['language' => $link['language']])
+      ->setAbsolute(TRUE)
+      ->toString();
+
+    $content['#language_switcher']['options'][] = [
+      'href' => $href,
+      'hreflang' => $language_code,
+      'label' => $link['title'],
+      'lang' => $language_code,
+    ];
+  }
+  $content['#language_switcher']['is_primary'] = TRUE;
+
+  return $build;
 }

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -108,7 +108,7 @@ function oe_multilingual_block_view_oe_theme_helper_page_header_alter(array &$bu
 function oe_multilingual_page_header_pre_render(array $build): array {
   // Get required services.
   $multilingual_helper = \Drupal::service('oe_multilingual.helper');
-  $language_provider = \Drupal::service('oe_multilingual.language_provider');
+  $content_language_switcher_provider = \Drupal::service('oe_multilingual.content_language_switcher_provider');
   $language_manager = \Drupal::languageManager();
 
   $entity = $multilingual_helper->getEntityFromCurrentRoute();
@@ -137,7 +137,7 @@ function oe_multilingual_page_header_pre_render(array $build): array {
   // Normalize the links to an array of options suitable for the ECL
   // "ecl-lang-select-pages" template.
   $content['#language_switcher']['options'] = [];
-  foreach ($language_provider->getAvailableEntityLanguages($entity) as $language_code => $link) {
+  foreach ($content_language_switcher_provider->getAvailableEntityLanguages($entity) as $language_code => $link) {
     /** @var \Drupal\Core\Url $url */
     $url = $link['url'];
     $href = $url

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -7,7 +7,9 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\Core\Url;
@@ -80,4 +82,78 @@ function oe_multilingual_configurable_language_presave(EntityInterface $entity) 
       $entity->set($key, $value);
     }
   }
+}
+
+/**
+ * Implements hook_block_view_BASE_BLOCK_ID_alter() for the Page Header block.
+ */
+function oe_multilingual_block_view_oe_theme_helper_page_header_alter(array &$build, BlockPluginInterface $block) {
+  $build['#pre_render'][] = 'oe_multilingual_page_header_pre_render';
+}
+
+/**
+ * Pre-render callback for the Page Header block alteration.
+ *
+ * We use this to add the language switcher
+ * to the page header if OpenEuropa Theme is being used.
+ *
+ * @param array $build
+ *   The built render array of the block.
+ *
+ * @see \Drupal\oe_theme_helper\Plugin\Block\PageHeaderBlock
+ *
+ * @return array
+ *   The built render array of the block.
+ */
+function oe_multilingual_page_header_pre_render(array $build): array {
+  // Get required services.
+  $multilingual_helper = \Drupal::service('oe_multilingual.helper');
+  $language_provider = \Drupal::service('oe_multilingual.language_provider');
+  $language_manager = \Drupal::languageManager();
+
+  $entity = $multilingual_helper->getEntityFromCurrentRoute();
+  // Bail out if there is no entity or if it's not a content entity.
+  if (!$entity || !$entity instanceof ContentEntityInterface) {
+    return $build;
+  }
+
+  // Render the links only if the current entity translation language is not
+  // the same as the current site language.
+  /** @var \Drupal\Core\Entity\EntityInterface $translation */
+  $translation = $multilingual_helper->getCurrentLanguageEntityTranslation($entity);
+  $current_language = $language_manager->getCurrentLanguage();
+  if ($translation->language()->getId() === $current_language->getId()) {
+    return $build;
+  }
+
+  $content = &$build['content'];
+
+  $content['#language_switcher']['current'] = $translation->language()->getName();
+
+  /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
+  $languages = $language_manager->getNativeLanguages();
+  $content['#language_switcher']['unavailable'] = $languages[$current_language->getId()]->getName();
+
+  // Normalize the links to an array of options suitable for the ECL
+  // "ecl-lang-select-pages" template.
+  $content['#language_switcher']['options'] = [];
+  foreach ($language_provider->getEntityAvailableLanguages($entity) as $language_code => $link) {
+    /** @var \Drupal\Core\Url $url */
+    $url = $link['url'];
+    $href = $url
+      ->setOptions(['language' => $link['language']])
+      ->setAbsolute(TRUE)
+      ->toString();
+
+    $content['#language_switcher']['options'][] = [
+      'href' => $href,
+      'hreflang' => $language_code,
+      'label' => $link['title'],
+      'lang' => $language_code,
+    ];
+  }
+
+  $content['#language_switcher']['is_primary'] = TRUE;
+
+  return $build;
 }

--- a/oe_multilingual.module
+++ b/oe_multilingual.module
@@ -106,8 +106,6 @@ function oe_multilingual_block_view_oe_theme_helper_page_header_alter(array &$bu
  *   The built render array of the block.
  */
 function oe_multilingual_page_header_pre_render(array $build): array {
-  $content = &$build['content'];
-
   // Get required services.
   $multilingual_helper = \Drupal::service('oe_multilingual.helper');
   $language_provider = \Drupal::service('oe_multilingual.language_provider');
@@ -128,8 +126,10 @@ function oe_multilingual_page_header_pre_render(array $build): array {
     return $build;
   }
 
-  $available_languages = $language_provider->getEntityAvailableLanguages($entity);
+  $content = &$build['content'];
+
   $content['#language_switcher']['current'] = $translation->language()->getName();
+
   /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
   $languages = $language_manager->getNativeLanguages();
   $content['#language_switcher']['unavailable'] = $languages[$current_language->getId()]->getName();
@@ -137,7 +137,7 @@ function oe_multilingual_page_header_pre_render(array $build): array {
   // Normalize the links to an array of options suitable for the ECL
   // "ecl-lang-select-pages" template.
   $content['#language_switcher']['options'] = [];
-  foreach ($available_languages as $language_code => $link) {
+  foreach ($language_provider->getEntityAvailableLanguages($entity) as $language_code => $link) {
     /** @var \Drupal\Core\Url $url */
     $url = $link['url'];
     $href = $url
@@ -152,6 +152,7 @@ function oe_multilingual_page_header_pre_render(array $build): array {
       'lang' => $language_code,
     ];
   }
+
   $content['#language_switcher']['is_primary'] = TRUE;
 
   return $build;

--- a/oe_multilingual.services.yml
+++ b/oe_multilingual.services.yml
@@ -6,7 +6,7 @@ services:
     class: Drupal\oe_multilingual\MultilingualHelper
     arguments: ['@entity.repository', '@current_route_match']
   oe_multilingual.language_provider:
-    class: Drupal\oe_multilingual\LanguageProvider
+    class: Drupal\oe_multilingual\ContentLanguageSwitcherProvider
     arguments: ['@language_manager', '@path.matcher', '@oe_multilingual.helper']
   oe_multilingual.content_language_settings:
     class: Drupal\oe_multilingual\MultilingualConfigOverride

--- a/oe_multilingual.services.yml
+++ b/oe_multilingual.services.yml
@@ -5,6 +5,9 @@ services:
   oe_multilingual.helper:
     class: Drupal\oe_multilingual\MultilingualHelper
     arguments: ['@entity.repository', '@current_route_match']
+  oe_multilingual.language_provider:
+    class: Drupal\oe_multilingual\LanguageProvider
+    arguments: ['@language_manager', '@path.matcher', '@oe_multilingual.helper']
   oe_multilingual.content_language_settings:
     class: Drupal\oe_multilingual\MultilingualConfigOverride
     tags:

--- a/oe_multilingual.services.yml
+++ b/oe_multilingual.services.yml
@@ -5,7 +5,7 @@ services:
   oe_multilingual.helper:
     class: Drupal\oe_multilingual\MultilingualHelper
     arguments: ['@entity.repository', '@current_route_match']
-  oe_multilingual.language_provider:
+  oe_multilingual.content_language_switcher_provider:
     class: Drupal\oe_multilingual\ContentLanguageSwitcherProvider
     arguments: ['@language_manager', '@path.matcher', '@oe_multilingual.helper']
   oe_multilingual.content_language_settings:

--- a/src/ContentLanguageSwitcherProvider.php
+++ b/src/ContentLanguageSwitcherProvider.php
@@ -11,7 +11,7 @@ use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Url;
 
 /**
- * Helper service around multilingual functionalities.
+ * Service that provides the content language switcher links for a given entity.
  */
 class ContentLanguageSwitcherProvider {
 

--- a/src/ContentLanguageSwitcherProvider.php
+++ b/src/ContentLanguageSwitcherProvider.php
@@ -13,7 +13,7 @@ use Drupal\Core\Url;
 /**
  * Helper service around multilingual functionalities.
  */
-class LanguageProvider {
+class ContentLanguageSwitcherProvider {
 
   /**
    * The multilingual helper service.
@@ -61,7 +61,7 @@ class LanguageProvider {
    * @return array
    *   Array of available translation links.
    */
-  public function getEntityAvailableLanguages(EntityInterface $entity) {
+  public function getAvailableEntityLanguages(EntityInterface $entity) {
     $route_name = $this->pathMatcher->isFrontPage() ? '<front>' : '<current>';
     $links = $this->languageManager->getLanguageSwitchLinks(LanguageInterface::TYPE_CONTENT, Url::fromRoute($route_name));
 

--- a/src/LanguageProvider.php
+++ b/src/LanguageProvider.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_multilingual;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\Url;
+
+/**
+ * Helper service around multilingual functionalities.
+ */
+class LanguageProvider {
+
+  /**
+   * The multilingual helper service.
+   *
+   * @var \Drupal\oe_multilingual\MultilingualHelperInterface
+   */
+  protected $multilingualHelper;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * The path matcher.
+   *
+   * @var \Drupal\Core\Path\PathMatcherInterface
+   */
+  protected $pathMatcher;
+
+  /**
+   * Constructs an ContentLanguageBlock object.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\Core\Path\PathMatcherInterface $path_matcher
+   *   The path matcher.
+   * @param \Drupal\oe_multilingual\MultilingualHelperInterface $multilingual_helper
+   *   The multilingual helper service.
+   */
+  public function __construct(LanguageManagerInterface $language_manager, PathMatcherInterface $path_matcher, MultilingualHelperInterface $multilingual_helper) {
+    $this->languageManager = $language_manager;
+    $this->pathMatcher = $path_matcher;
+    $this->multilingualHelper = $multilingual_helper;
+  }
+
+  /**
+   * Returns a list of available translation links for a given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The language manager.
+   *
+   * @return array
+   *   Array of available translation links.
+   */
+  public function getEntityAvailableLanguages(EntityInterface $entity) {
+    $available_languages = [];
+
+    $translation = $this->multilingualHelper->getCurrentLanguageEntityTranslation($entity);
+    $route_name = $this->pathMatcher->isFrontPage() ? '<front>' : '<current>';
+    $links = $this->languageManager->getLanguageSwitchLinks(LanguageInterface::TYPE_CONTENT, Url::fromRoute($route_name));
+
+    if (isset($links->links)) {
+      // Only show links to the available translation languages except the
+      // current one.
+      $available_languages = array_intersect_key($links->links, $entity->getTranslationLanguages());
+      unset($available_languages[$translation->language()->getId()]);
+    }
+
+    return $available_languages;
+  }
+
+}

--- a/src/LanguageProvider.php
+++ b/src/LanguageProvider.php
@@ -62,16 +62,15 @@ class LanguageProvider {
    *   Array of available translation links.
    */
   public function getEntityAvailableLanguages(EntityInterface $entity) {
-    $available_languages = [];
-
-    $translation = $this->multilingualHelper->getCurrentLanguageEntityTranslation($entity);
     $route_name = $this->pathMatcher->isFrontPage() ? '<front>' : '<current>';
     $links = $this->languageManager->getLanguageSwitchLinks(LanguageInterface::TYPE_CONTENT, Url::fromRoute($route_name));
 
+    $available_languages = [];
     if (isset($links->links)) {
       // Only show links to the available translation languages except the
       // current one.
       $available_languages = array_intersect_key($links->links, $entity->getTranslationLanguages());
+      $translation = $this->multilingualHelper->getCurrentLanguageEntityTranslation($entity);
       unset($available_languages[$translation->language()->getId()]);
     }
 

--- a/src/Plugin/Block/ContentLanguageBlock.php
+++ b/src/Plugin/Block/ContentLanguageBlock.php
@@ -98,6 +98,8 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
 
     $available_languages = $this->contentLanguageSwitcherProvider->getAvailableEntityLanguages($entity);
 
+    // Currently the language switcher block cannot be cached:
+    // https://www.drupal.org/node/2232375
     $build = [
       '#theme' => 'links__oe_multilingual_content_language_block',
       '#links' => $available_languages,
@@ -108,7 +110,6 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
       ],
       '#set_active_class' => TRUE,
     ];
-
     return $build;
   }
 

--- a/src/Plugin/Block/ContentLanguageBlock.php
+++ b/src/Plugin/Block/ContentLanguageBlock.php
@@ -32,11 +32,11 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
   protected $multilingualHelper;
 
   /**
-   * The language provider.
+   * The content language switcher provider.
    *
    * @var \Drupal\oe_multilingual\ContentLanguageSwitcherProvider
    */
-  protected $languageProvider;
+  protected $contentLanguageSwitcherProvider;
 
   /**
    * Constructs an ContentLanguageBlock object.
@@ -53,13 +53,13 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
    *   The path matcher.
    * @param \Drupal\oe_multilingual\MultilingualHelperInterface $multilingual_helper
    *   The multilingual helper service.
-   * @param \Drupal\oe_multilingual\ContentLanguageSwitcherProvider $language_provider
-   *   The language provider.
+   * @param \Drupal\oe_multilingual\ContentLanguageSwitcherProvider $content_language_switcher_provider
+   *   The content language switcher provider.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, LanguageManagerInterface $language_manager, PathMatcherInterface $path_matcher, MultilingualHelperInterface $multilingual_helper, ContentLanguageSwitcherProvider $language_provider) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LanguageManagerInterface $language_manager, PathMatcherInterface $path_matcher, MultilingualHelperInterface $multilingual_helper, ContentLanguageSwitcherProvider $content_language_switcher_provider) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $language_manager, $path_matcher);
     $this->multilingualHelper = $multilingual_helper;
-    $this->languageProvider = $language_provider;
+    $this->contentLanguageSwitcherProvider = $content_language_switcher_provider;
   }
 
   /**
@@ -73,7 +73,7 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
       $container->get('language_manager'),
       $container->get('path.matcher'),
       $container->get('oe_multilingual.helper'),
-      $container->get('oe_multilingual.language_provider')
+      $container->get('oe_multilingual.content_language_switcher_provider')
     );
   }
 
@@ -96,7 +96,7 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
       return $build;
     }
 
-    $available_languages = $this->languageProvider->getAvailableEntityLanguages($entity);
+    $available_languages = $this->contentLanguageSwitcherProvider->getAvailableEntityLanguages($entity);
 
     $build = [
       '#theme' => 'links__oe_multilingual_content_language_block',

--- a/src/Plugin/Block/ContentLanguageBlock.php
+++ b/src/Plugin/Block/ContentLanguageBlock.php
@@ -98,18 +98,16 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
 
     $available_languages = $this->languageProvider->getEntityAvailableLanguages($entity);
 
-    if ($available_languages) {
-      $build = [
-        '#theme' => 'links__oe_multilingual_content_language_block',
-        '#links' => $available_languages,
-        '#attributes' => [
-          'class' => [
-            "language-switcher",
-          ],
+    $build = [
+      '#theme' => 'links__oe_multilingual_content_language_block',
+      '#links' => $available_languages,
+      '#attributes' => [
+        'class' => [
+          "language-switcher",
         ],
-        '#set_active_class' => TRUE,
-      ];
-    }
+      ],
+      '#set_active_class' => TRUE,
+    ];
 
     return $build;
   }

--- a/src/Plugin/Block/ContentLanguageBlock.php
+++ b/src/Plugin/Block/ContentLanguageBlock.php
@@ -10,7 +10,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\language\Plugin\Block\LanguageBlock;
 use Drupal\oe_multilingual\MultilingualHelperInterface;
-use Drupal\oe_multilingual\LanguageProvider;
+use Drupal\oe_multilingual\ContentLanguageSwitcherProvider;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,7 +34,7 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
   /**
    * The language provider.
    *
-   * @var \Drupal\oe_multilingual\LanguageProvider
+   * @var \Drupal\oe_multilingual\ContentLanguageSwitcherProvider
    */
   protected $languageProvider;
 
@@ -53,10 +53,10 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
    *   The path matcher.
    * @param \Drupal\oe_multilingual\MultilingualHelperInterface $multilingual_helper
    *   The multilingual helper service.
-   * @param \Drupal\oe_multilingual\LanguageProvider $language_provider
+   * @param \Drupal\oe_multilingual\ContentLanguageSwitcherProvider $language_provider
    *   The language provider.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, LanguageManagerInterface $language_manager, PathMatcherInterface $path_matcher, MultilingualHelperInterface $multilingual_helper, LanguageProvider $language_provider) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LanguageManagerInterface $language_manager, PathMatcherInterface $path_matcher, MultilingualHelperInterface $multilingual_helper, ContentLanguageSwitcherProvider $language_provider) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $language_manager, $path_matcher);
     $this->multilingualHelper = $multilingual_helper;
     $this->languageProvider = $language_provider;
@@ -96,7 +96,7 @@ class ContentLanguageBlock extends LanguageBlock implements ContainerFactoryPlug
       return $build;
     }
 
-    $available_languages = $this->languageProvider->getEntityAvailableLanguages($entity);
+    $available_languages = $this->languageProvider->getAvailableEntityLanguages($entity);
 
     $build = [
       '#theme' => 'links__oe_multilingual_content_language_block',

--- a/tests/features/content-language-switcher.feature
+++ b/tests/features/content-language-switcher.feature
@@ -9,27 +9,41 @@ Feature: Content language selector
     Given the following "Demo translatable page" content item:
       | Title | Page title |
       | Body  | Page body  |
-    And the following "Italian" translation for the "Demo translatable page" with title "Page title":
-      | Title | Titolo pagina |
-      | Body  | Testo pagina  |
     And the following "Greek" translation for the "Demo translatable page" with title "Page title":
       | Title | Τίτλος σελίδας  |
       | Body  | Σελίδα κειμένου |
     And the following "Spanish" translation for the "Demo translatable page" with title "Page title":
       | Title | Título de página  |
       | Body  | Texto de página   |
+    And the following "Italian" translation for the "Demo translatable page" with title "Page title":
+      | Title | Titolo pagina |
+      | Body  | Testo pagina  |
 
   Scenario: Visitor navigating to an available translation shouldn't see the language selector
-    Given I visit the "Page title" content
+    When I visit the "Page title" content
     Then I should see the heading "Page title"
     And I should see "Page body"
-    And I should not see the link "Spanish" in the "page header" region
+
+    And I should not see the link "ελληνικά" in the "page content" region
+    And I should not see the link "español" in the "page content" region
+    And I should not see the link "italiano" in the "page content" region
+
+  Scenario: Visitor navigating to an available translation shouldn't see the language selector
+    When I visit the "Page title" content
+    And I click "italiano"
+    Then I should see the heading "Titolo pagina"
+    And I should see "Testo pagina"
+
+    And I should not see the link "ελληνικά" in the "page content" region
+    And I should not see the link "English" in the "page content" region
+    And I should not see the link "español" in the "page content" region
 
   Scenario: Visitor navigating to an unavailable translation should see the language selector
-    Given I visit the "Page title" content
+    When I visit the "Page title" content
+    And I click "Deutsch"
     Then I should see the heading "Page title"
     And I should see "Page body"
-    When I click "български"
-    Then I should see the heading "Page title"
-    And I should see "Page body"
-    And I should see the link "español" in the "page header" region
+
+    And I should see the link "ελληνικά" in the "page content" region
+    And I should see the link "español" in the "page content" region
+    And I should see the link "italiano" in the "page content" region

--- a/tests/features/content-language-switcher.feature
+++ b/tests/features/content-language-switcher.feature
@@ -19,7 +19,7 @@ Feature: Content language selector
       | Title | Titolo pagina |
       | Body  | Testo pagina  |
 
-  Scenario: Visitor navigating to an available translation shouldn't see the language selector
+  Scenario: Visitor navigating to the original content shouldn't see the language selector
     When I visit the "Page title" content
     Then I should see the heading "Page title"
     And I should see "Page body"

--- a/tests/features/content-language-switcher.feature
+++ b/tests/features/content-language-switcher.feature
@@ -24,9 +24,9 @@ Feature: Content language selector
     Then I should see the heading "Page title"
     And I should see "Page body"
 
-    And I should not see the link "ελληνικά" in the "page content" region
-    And I should not see the link "español" in the "page content" region
-    And I should not see the link "italiano" in the "page content" region
+    And I should not see the link "ελληνικά" in the "page content"
+    And I should not see the link "español" in the "page content"
+    And I should not see the link "italiano" in the "page content"
 
   Scenario: Visitor navigating to an available translation shouldn't see the language selector
     When I visit the "Page title" content
@@ -34,9 +34,9 @@ Feature: Content language selector
     Then I should see the heading "Titolo pagina"
     And I should see "Testo pagina"
 
-    And I should not see the link "ελληνικά" in the "page content" region
-    And I should not see the link "English" in the "page content" region
-    And I should not see the link "español" in the "page content" region
+    And I should not see the link "ελληνικά" in the "page content"
+    And I should not see the link "English" in the "page content"
+    And I should not see the link "español" in the "page content"
 
   Scenario: Visitor navigating to an unavailable translation should see the language selector
     When I visit the "Page title" content
@@ -44,6 +44,6 @@ Feature: Content language selector
     Then I should see the heading "Page title"
     And I should see "Page body"
 
-    And I should see the link "ελληνικά" in the "page content" region
-    And I should see the link "español" in the "page content" region
-    And I should see the link "italiano" in the "page content" region
+    And I should see the link "ελληνικά" in the "page content"
+    And I should see the link "español" in the "page content"
+    And I should see the link "italiano" in the "page content"

--- a/tests/features/translation.feature
+++ b/tests/features/translation.feature
@@ -14,8 +14,8 @@ Feature: Translate content
     And I press "Save"
 
     Then I should see the success message "Demo translatable page Test page has been created."
-    And I should see "Test page" in the "page header"
-    And I should see "This is a test" in the "page header"
+    And I should see "Test page" in the "page content"
+    And I should see "This is a test" in the "page content"
 
     # Translate the Translatable page content into Spanish.
     When I click "Translate"
@@ -25,6 +25,6 @@ Feature: Translate content
     And I press "Save (this translation)"
 
     Then I should see the success message "Demo translatable page Página de prueba has been updated."
-    And I should see "Página de prueba" in the "page header"
-    And I should see "Esto es una prueba" in the "page header"
+    And I should see "Página de prueba" in the "page content"
+    And I should see "Esto es una prueba" in the "page content"
 


### PR DESCRIPTION
## OPENEUROPA-1754:

### Description

Move content language switcher to header.

### Change log

- Added:
- Changed: Move content language switcher to header.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

