### PR TITLE
OPENEUROPA-1811: Fix issue with image styles generating related to language selection page.

### DIFF
--- a/modules/oe_multilingual_selection_page/oe_multilingual_selection_page.install
+++ b/modules/oe_multilingual_selection_page/oe_multilingual_selection_page.install
@@ -26,6 +26,7 @@ function oe_multilingual_selection_page_install(): void {
       '/admin*',
       '/node/add/*',
       '/node/*/edit',
+      '/sites/*/files/*',
     ])->save();
 
   /** @var \Drupal\oe_multilingual\LanguageNegotiationSetterInterface $setter */
@@ -39,4 +40,16 @@ function oe_multilingual_selection_page_install(): void {
   $setter->addInterfaceSettings([
     LanguageNegotiationLanguageSelectionPage::METHOD_ID => -18,
   ]);
+}
+
+/**
+ * Add files directory to blacklisted paths.
+ */
+function oe_multilingual_selection_page_update_8001() {
+  $config = \Drupal::configFactory()
+    ->getEditable('language_selection_page.negotiation');
+  $blacklist = $config->get('blacklisted_paths');
+  $blacklist[] = '/sites/*/files/*';
+  $config->set('blacklisted_paths', $blacklist);
+  $config->save();
 }


### PR DESCRIPTION
## OPENEUROPA-1811

### Description

Investigate this problem and try to fix it.

To replicate:
 * Create a news item with a featured image that you upload
 * Save and see the that image is not found
 * Refresh the page once or twice and the see the image shows up

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

