### PR TITLE
OPENEUROPA-1794: Bug in the OE Multilingual uninstallation.

### DIFF
--- a/oe_multilingual.install
+++ b/oe_multilingual.install
@@ -76,6 +76,22 @@ function oe_multilingual_install() {
 }
 
 /**
+ * Implements hook_uninstall().
+ */
+function oe_multilingual_uninstall() {
+  /** @var \Drupal\oe_multilingual\LanguageNegotiationSetterInterface $setter */
+  $setter = \Drupal::service('oe_multilingual.language_negotiation_setter');
+
+  // Unset the LanguageNegotiationAdmin plugin from the interface negotiation.
+  // This is needed because the plugin is defined by this module.
+  $setter->setInterfaceSettings([
+    // By default, the URL based negotiation is the highest priority one.
+    LanguageNegotiationUrl::METHOD_ID => -19,
+    LanguageNegotiationSelected::METHOD_ID => 20,
+  ]);
+}
+
+/**
  * Ensures that local entries exist for the configuration translations.
  *
  * Because we are shipping with pre-existing config translations for the

--- a/oe_multilingual.install
+++ b/oe_multilingual.install
@@ -79,16 +79,23 @@ function oe_multilingual_install() {
  * Implements hook_uninstall().
  */
 function oe_multilingual_uninstall() {
-  /** @var \Drupal\oe_multilingual\LanguageNegotiationSetterInterface $setter */
-  $setter = \Drupal::service('oe_multilingual.language_negotiation_setter');
-
   // Unset the LanguageNegotiationAdmin plugin from the interface negotiation.
   // This is needed because the plugin is defined by this module.
-  $setter->setInterfaceSettings([
-    // By default, the URL based negotiation is the highest priority one.
-    LanguageNegotiationUrl::METHOD_ID => -19,
-    LanguageNegotiationSelected::METHOD_ID => 20,
-  ]);
+  $names = [
+    'negotiation.' . LanguageInterface::TYPE_INTERFACE . '.enabled',
+    'negotiation.' . LanguageInterface::TYPE_INTERFACE . '.method_weights',
+  ];
+
+  $config = \Drupal::configFactory()->getEditable('language.types');
+  foreach ($names as $name) {
+    $settings = $config->get($name);
+    if (isset($settings[LanguageNegotiationAdmin::METHOD_ID])) {
+      unset($settings[LanguageNegotiationAdmin::METHOD_ID]);
+    }
+    $config->set($name, $settings);
+  }
+
+  $config->save();
 }
 
 /**

--- a/tests/Kernel/InstallationTest.php
+++ b/tests/Kernel/InstallationTest.php
@@ -42,6 +42,8 @@ class InstallationTest extends KernelTestBase {
       'locale_file',
     ]);
 
+    $this->installSchema('user', ['users_data']);
+
     $this->installConfig([
       'locale',
       'language',
@@ -117,6 +119,24 @@ class InstallationTest extends KernelTestBase {
     $this->assertEquals($interface_settings, $config->get('negotiation.' . LanguageInterface::TYPE_INTERFACE . '.method_weights'));
     $this->assertEquals($content_settings, $config->get('negotiation.' . LanguageInterface::TYPE_CONTENT . '.enabled'));
     $this->assertEquals($content_settings, $config->get('negotiation.' . LanguageInterface::TYPE_CONTENT . '.method_weights'));
+  }
+
+  /**
+   * Tests that uninstalling the module leaves the site in working condition.
+   *
+   * There can be plugins defined by the module which could no longer be found
+   * otherwise.
+   */
+  public function testUninstall() {
+    $this->container->get('module_installer')->uninstall(['oe_multilingual']);
+
+    $config = $this->config('language.types');
+    $interface_settings = [
+      LanguageNegotiationUrl::METHOD_ID => -19,
+      LanguageNegotiationSelected::METHOD_ID => 20,
+    ];
+    $this->assertEquals($interface_settings, $config->get('negotiation.' . LanguageInterface::TYPE_INTERFACE . '.enabled'));
+    $this->assertEquals($interface_settings, $config->get('negotiation.' . LanguageInterface::TYPE_INTERFACE . '.method_weights'));
   }
 
 }


### PR DESCRIPTION
Fixes a problem with uninstalling OE Multilingual. The admin interface language negotiation plugin needs to be removed.

First commit proves the bug. The second one fixes it.

