### PR TITLE
OPENEUROPA-2111: Remove English translations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The OpenEuropa Multilingual module offers default multilingual features for the 
 - Enable all 24 official EU languages
 - Provide an optional language switcher block on the [OpenEuropa Theme][1] site header region
 - Make sure that the administrative interface is always set to English
-- (TEMPORARILY REMOVED) Allow English to be translated so that the default English copy may be fixed or improved, if necessary.
 
 **Table of contents:**
 
@@ -185,12 +184,10 @@ In order to install the OpenEuropa Multilingual demo module follow [the instruct
 
 ## Known Issues
 
-##### Enabling English translations allows configuration changes to override locale translations
+##### Enabling string English string translation
 
-Having English translations available had an unintended consequence: when making changes to translatable config entities, 
-if the strings of this config entities were also available on locale they would get saved as translations. The functionality
-was removed on OPENEUROPA-2111 and a solution is currently being investigated on OPENEUROPA-2244
-
+Enabling English string translation can have unintended consequences when making changes to translatable configuration entities.
+If these strings are available in locale, the change would get saved as EN translations.
  
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The OpenEuropa Multilingual module offers default multilingual features for the 
 - Enable all 24 official EU languages
 - Provide an optional language switcher block on the [OpenEuropa Theme][1] site header region
 - Make sure that the administrative interface is always set to English
-- Allow English to be translated so that the default English copy may be fixed or improved, if necessary
+- (TEMPORARILY REMOVED) Allow English to be translated so that the default English copy may be fixed or improved, if necessary.
 
 **Table of contents:**
 
@@ -182,6 +182,16 @@ In order to install the OpenEuropa Multilingual demo module follow [the instruct
 ```bash
 ./vendor/bin/drush en oe_multilingual_demo -y
 ```
+
+## Known Issues
+
+##### Enabling English translations allows configuration changes to override locale translations
+
+Having English translations available had an unintended consequence: when making changes to translatable config entities, 
+if the strings of this config entities were also available on locale they would get saved as translations. The functionality
+was removed on OPENEUROPA-2111 and a solution is currently being investigated on OPENEUROPA-2244
+
+ 
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "openeuropa/drupal-core-require-dev": "^8.7",
         "openeuropa/task-runner": "~1.0@beta",
         "phpunit/phpunit": "~6.0",
-        "symfony/browser-kit": "~3.0 || ~4.0"
+        "symfony/browser-kit": "~3.0 || ~4.0",
+        "behat/mink-selenium2-driver": "1.4.x-dev as 1.3.x-dev"
     },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/oe_multilingual.install
+++ b/oe_multilingual.install
@@ -32,7 +32,6 @@ function oe_multilingual_install() {
   \Drupal::configFactory()
     ->getEditable('locale.settings')
     ->set('translation.import_enabled', FALSE)
-    ->set('translate_english', TRUE)
     ->save();
 
   // Make sure that English language prefix is set to "en".

--- a/oe_multilingual.post_update.php
+++ b/oe_multilingual.post_update.php
@@ -16,15 +16,3 @@ declare(strict_types = 1);
 function oe_multilingual_post_update_00001_invalidate_containers_cache(): void {
   \Drupal::service('kernel')->invalidateContainer();
 }
-
-/**
- * Disable English translation.
- *
- * Disable English translations to prevent configuration changes to be
- * stored as locale translations.
- */
-function oe_multilingual_post_update_00002_disable_english_translation(): void {
-  $locale_configuration = \Drupal::configFactory()->getEditable('locale.settings');
-  $locale_configuration->set('translate_english', FALSE);
-  $locale_configuration->save();
-}

--- a/oe_multilingual.post_update.php
+++ b/oe_multilingual.post_update.php
@@ -16,3 +16,15 @@ declare(strict_types = 1);
 function oe_multilingual_post_update_00001_invalidate_containers_cache(): void {
   \Drupal::service('kernel')->invalidateContainer();
 }
+
+/**
+ * Disable English translation.
+ *
+ * Disable English translations to prevent configuration changes to be
+ * stored as locale translations.
+ */
+function oe_multilingual_post_update_00002_disable_english_translation(): void {
+  $locale_configuration = \Drupal::configFactory()->getEditable('locale.settings');
+  $locale_configuration->set('translate_english', FALSE);
+  $locale_configuration->save();
+}

--- a/tests/Behat/InterfaceTranslationContext.php
+++ b/tests/Behat/InterfaceTranslationContext.php
@@ -41,8 +41,8 @@ class InterfaceTranslationContext extends RawDrupalContext {
     $source = $locale_storage->findString(['source' => $string]);
     if (!$source instanceof SourceString) {
       // We need to make sure the string is available to be translated.
-      $source = new SourceString();
-      $source->setString($string)->setStorage($locale_storage)->save();
+      $source = $locale_storage->createString();
+      $source->setString($string)->save();
     }
 
     // Backup existing translation.

--- a/tests/Behat/InterfaceTranslationContext.php
+++ b/tests/Behat/InterfaceTranslationContext.php
@@ -40,7 +40,9 @@ class InterfaceTranslationContext extends RawDrupalContext {
 
     $source = $locale_storage->findString(['source' => $string]);
     if (!$source instanceof SourceString) {
-      throw new \Exception(sprintf('Missing string to translate: %s', $source));
+      // We need to make sure the string is available to be translated.
+      $source = new SourceString();
+      $source->setString($string)->setStorage($locale_storage)->save();
     }
 
     // Backup existing translation.

--- a/tests/Kernel/InstallationTest.php
+++ b/tests/Kernel/InstallationTest.php
@@ -93,8 +93,8 @@ class InstallationTest extends KernelTestBase {
     // Ensure that remote translations downloading is disabled by default.
     $this->assertEquals(FALSE, $config->get('translation.import_enabled'));
 
-    // Ensure that the English language is translatable.
-    $this->assertEquals(TRUE, $config->get('translate_english'));
+    // Ensure that the English language is not translatable.
+    $this->assertEquals(FALSE, $config->get('translate_english'));
 
     $interface_settings = [
       LanguageNegotiationAdmin::METHOD_ID => -20,


### PR DESCRIPTION
## OPENEUROPA-2111

### Description

We found out that having English translations available had an unintended consequence: when making changes to translatable config entities, if the strings of this config entities were also available on locale they would get saved as translations.

We need to remove the English translation for the time being.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed: English translation.
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

