### PR TITLE
OPENEUROPA-2604: Update pathauto to prepare for Drupal 8.8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1",
         "drupal/core": "^8.7",
         "drupal/language_selection_page": "2.3",
-        "drupal/pathauto": "^1.2"
+        "drupal/pathauto": "^1.6"
     },
     "require-dev": {
         "composer/installers": "~1.5",


### PR DESCRIPTION
## OPENEUROPA-2604
### Description

The minumim version of pathauto needs to be increased in order to update to Drupal 8.8
### Change log

- Added:
- Changed: Minimum version of pathauto increased.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

