### PR TITLE
OPENEUROPA-2652: Use patch to add language cache tags to selection page.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.1",
         "drupal/core": "^8.7",
-        "drupal/language_selection_page": "^2.2",
+        "drupal/language_selection_page": "2.3",
         "drupal/pathauto": "^1.2"
     },
     "require-dev": {
@@ -60,6 +60,11 @@
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],
             "build/modules/contrib/{$name}": ["type:drupal-module"],
             "build/themes/contrib/{$name}": ["type:drupal-theme"]
+        },
+        "patches": {
+            "drupal/language_selection_page": {
+                "https://www.drupal.org/project/language_selection_page/issues/3105633": "https://www.drupal.org/files/issues/2020-01-27/3105633-6-stable.patch"
+            }
         },
         "drush": {
             "services": {


### PR DESCRIPTION
## OPENEUROPA-2652

### Description

The language selection page doesn't use the proper cache tags so it doesn't get invalidated on CRUD operations on languages. This PR adds the required language list tag.
### Change log

- Added: Language list cache tag to language selection page.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

