### PR TITLE
OPENEUROPA-0000: Use drupal/core instead of drupal/core-recommended.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "drupal/core-recommended": "^8.7",
+        "drupal/core": "^8.7",
         "drupal/language_selection_page": "2.3",
         "drupal/pathauto": "^1.6"
     },


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

