### PR TITLE
OEL-281: Update languageNegotiation method.

### DIFF
--- a/src/Plugin/LanguageNegotiation/LanguageNegotiationAdmin.php
+++ b/src/Plugin/LanguageNegotiation/LanguageNegotiationAdmin.php
@@ -23,7 +23,7 @@ class LanguageNegotiationAdmin extends LanguageNegotiationUserAdmin {
   /**
    * The language negotiation method id.
    */
-  const METHOD_ID = 'language-admin';
+  const METHOD_ID = 'language-user-admin';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
## OPENEUROPA-OEL-281

Update LanguageNegotiationMethod to language-user-admin.

The LanguageNegotiationMethod in Drupal 8/9 has been updated from language-admin to language-user-admin.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

