### PR TITLE
PoC: Testing: Call ->drupalLogin() with language suffix enabled.

### DIFF
--- a/modules/oe_multilingual_url_suffix/tests/src/Functional/LanguageNegotiationUrlSuffixTest.php
+++ b/modules/oe_multilingual_url_suffix/tests/src/Functional/LanguageNegotiationUrlSuffixTest.php
@@ -74,6 +74,12 @@ class LanguageNegotiationUrlSuffixTest extends BrowserTestBase {
     ];
     $this->drupalGet('admin/config/regional/language/detection');
     $this->submitForm($edit, 'Save settings');
+
+    // Reload config that has changed.
+    // @todo Use a less aggressive method.
+    $this->rebuildContainer();
+    // Check if the ->drupalLogin() method works with language suffix.
+    $this->drupalLogin($this->user);
   }
 
   /**


### PR DESCRIPTION
See https://www.drupal.org/project/drupal/issues/3599305